### PR TITLE
Update MONAI Bundle and MONAI Model Zoo.ipynb

### DIFF
--- a/MONAICore/MONAI Bundle and MONAI Model Zoo.ipynb
+++ b/MONAICore/MONAI Bundle and MONAI Model Zoo.ipynb
@@ -94,7 +94,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -c \"import monai\" || pip install -qU \"monai[ignite, nibabel, torchvision, tqdm, fire]==1.1.0\""
+    "!python -c \"import monai\" || pip install -qU \"monai[ignite, nibabel, torchvision, tqdm, fire]==1.2.0\""
    ]
   },
   {


### PR DESCRIPTION
Updated monai package version to 1.2.0 to fix build error for MONAI Bundle and Model Zoo notebook.